### PR TITLE
Decode Ways

### DIFF
--- a/Decode Ways
+++ b/Decode Ways
@@ -1,0 +1,50 @@
+A message containing letters from A-Z can be encoded into numbers using the following mapping:
+
+'A' -> "1"
+'B' -> "2"
+...
+'Z' -> "26"
+To decode an encoded message, all the digits must be grouped then mapped back into letters using the reverse of the mapping above (there may be multiple ways). For example, "11106" can be mapped into:
+
+"AAJF" with the grouping (1 1 10 6)
+"KJF" with the grouping (11 10 6)
+Note that the grouping (1 11 06) is invalid because "06" cannot be mapped into 'F' since "6" is different from "06".
+
+Given a string s containing only digits, return the number of ways to decode it.
+
+The test cases are generated so that the answer fits in a 32-bit integer.
+
+Code: 
+
+int rec(int i,string& s,vector<int>&dp){
+        if(i>s.length()-1){return 1;}
+        if(s[i]=='0'){
+            return 0;
+        }
+        if(i==s.length()-1){return 1;}
+        if(dp[i]!=-1){return dp[i];}
+        int ans=0,ans1=0;
+        if(s[i]>'2'){
+            ans+=rec(i+1,s,dp);
+        }
+        else if(i+1<s.length()&&((s[i]=='2'&&s[i+1]<='6')||(s[i]=='1'&&s[i+1]<='9'))){
+            if(s[i+1]=='0'){
+                ans1+=rec(i+2,s,dp);
+            }
+            else{
+                ans+=rec(i+1,s,dp);
+                ans1+=rec(i+2,s,dp);
+            }
+        }
+        else {
+            ans+=rec(i+1,s,dp);
+        }
+        // else{}
+        return dp[i]=ans+ans1;
+        
+        
+    }
+    int numDecodings(string s) {
+        vector<int>dp(s.length(),-1);
+        return rec(0,s,dp);
+    }


### PR DESCRIPTION
A message containing letters from A-Z can be encoded into numbers using the following mapping:

'A' -> "1"
'B' -> "2"
...
'Z' -> "26"
To decode an encoded message, all the digits must be grouped then mapped back into letters using the reverse of the mapping above (there may be multiple ways). For example, "11106" can be mapped into:

"AAJF" with the grouping (1 1 10 6)
"KJF" with the grouping (11 10 6)
Note that the grouping (1 11 06) is invalid because "06" cannot be mapped into 'F' since "6" is different from "06".

Given a string s containing only digits, return the number of ways to decode it.

The test cases are generated so that the answer fits in a 32-bit integer.